### PR TITLE
Add grav fixes

### DIFF
--- a/.vf_signatures
+++ b/.vf_signatures
@@ -703,7 +703,7 @@ $SIGNATURES = {
         'base' => '#home-text .download-button',
         'major' => 1,
         'minor' => 2,
-        'regex' => 'Download WordPress ([0-9.]*)',
+        'regex' => 'Download(?:\\s|&nbsp;)WordPress(?:\\s|&nbsp;)([0-9.]*)',
         'single' => 1,
         'url' => 'https://wordpress.org/'
       }

--- a/.vf_signatures
+++ b/.vf_signatures
@@ -149,6 +149,38 @@ $SIGNATURES = {
       }
     ]
   },
+  'grav' => {
+    'fingerprints' => [
+      {
+        'file' => 'system/defines.php',
+        'regex' => 'grav'
+      }
+    ],
+    'name' => 'Grav',
+    'releases' => {
+      '1' => {
+        'minor' => '1',
+        'release' => '1.1.3'
+      }
+    },
+    'update' => {
+      '1' => {
+        'base' => '.version strong',
+        'major' => 1,
+        'minor' => 1,
+        'regex' => '([0-9.]*)',
+        'single' => 1,
+        'url' => 'https://getgrav.org/downloads'
+      }
+    },
+    'versions' => [
+      {
+        'file' => 'system/defines.php',
+        'multiline' => 1,
+        'regex' => 'define.*GRAV_VERSION\', \'(.*)\''
+      }
+    ]
+  },
   'joomla' => {
     'fingerprints' => [
       {
@@ -289,15 +321,15 @@ $SIGNATURES = {
     'releases' => {
       '1.23' => {
         'minor' => '1.23',
-        'release' => '1.23.14'
+        'release' => '1.23.15'
       },
       '1.26' => {
         'minor' => '1.26',
-        'release' => '1.26.3'
+        'release' => '1.26.4'
       },
       '1.27' => {
         'minor' => '1.27',
-        'release' => '1.27.0'
+        'release' => '1.27.1'
       }
     },
     'update' => {


### PR DESCRIPTION
I've added [Grav CMS](https://getgrav.org/) and fixed an issue with Wordpress. For some reason wordpress.org is replacing spaces with `&nbsp;`. I'm no expert on regexes but the one committed seems to work.
